### PR TITLE
Add django-debug-toolbar to packages

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,3 +9,4 @@
 - [xqsz](https://github.com/xqsz)
 - [louisparis](https://github.com/louisparis)
 - [fofam3](https://github.com/fofam3)
+- [wangonya](https://github.com/wangonya)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Since newer versions of Python are often faster, have more features, and are bet
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/tox.svg)](https://docs.djangoproject.com/en/2.1/faq/install/#what-python-version-can-i-use-with-django)
 [![GitHub contributors](https://img.shields.io/github/contributors/endormi/django.svg)](https://github.com/endormi/django/blob/master/AUTHORS.md)
 
-### Page content: 
+### Page content:
 
 - [Building Web Applications](#building-web-applications-)
     - [Scalability](#scalability)
@@ -108,6 +108,7 @@ A list of awesome packages (not in a specific order):
 - [django-registration](https://django-registration.readthedocs.io/en/3.0/)
 - [django-two-factor-auth](https://django-two-factor-auth.readthedocs.io/en/stable/)
 - [django-favorite](https://pypi.org/project/django-favorite/)
+- [django-debug-toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/index.html)
 
 ## Documentation 📑
 


### PR DESCRIPTION
<!--
  Have any questions? Open a new issue. :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR adds [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar) to packages. django-debug-toolbar helps in debugging by adding a toolbar on the right side of your Django page while in development.
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Addresses #11 


